### PR TITLE
JWIS-00003 Invalid branch name no longer opens all changed files ever

### DIFF
--- a/scripts/openCommitsIn
+++ b/scripts/openCommitsIn
@@ -29,7 +29,12 @@ filesNotFound() {
 
 if [ -z "$1" ]; then
   TICKET=$(git rev-parse --abbrev-ref HEAD | grep -Eo '([A-Z]{3,}-)([0-9]+)' -m 1)
-  
+
+  if [ "$TICKET" == "" ]; then
+    echo "No ticket entered, and invalid branch name.  Please enter a valid ticket"
+    exit 1
+  fi
+
   echo "No ticket entered, using branch name $TICKET."
 else
   if [[ $1 =~ ^([A-Z]{3,}-)([0-9]+)$ ]]; then


### PR DESCRIPTION
Using `openCommitsIn` without specifying a ticket number while having a branch name without 3+ upper-case letters, a dash, and then numbers would cause `openCommitsIn` to attempt to open EVERY file changed in history.