### PR TITLE
Create prepare-commit-message.sample

### DIFF
--- a/githooks/prepare-commit-message.sample
+++ b/githooks/prepare-commit-message.sample
@@ -17,7 +17,10 @@ USER=git var GIT_AUTHOR_IDENT
 NAME=$(git branch | grep '*' | sed 's/* //') 
 DESCRIPTION=$(git config branch."$NAME".description)
 
-echo "[<TOPIC> : $USER] <DETAILS> - $JIRA_TICKET"|cat - "$1" > /tmp/out && mv /tmp/out "$1"
+# if you want a different message, add it here
+HOOK_MESSAGE="[<TOPIC> : $USER] <DETAILS> - $JIRA_TICKET"
+
+echo "$HOOK_MESSAGE"|cat - "$1" > /tmp/out && mv /tmp/out "$1"
 if [ -n "$DESCRIPTION" ] 
 then
    echo "" >> "$1"

--- a/githooks/prepare-commit-message.sample
+++ b/githooks/prepare-commit-message.sample
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# An example hook script to prepare the commit log message.
+# Called by "git commit" with the name of the file that has the
+# commit message, followed by the description of the commit
+# message's source.  The hook's purpose is to edit the commit
+# message file.  If the hook fails with a non-zero status,
+# the commit is aborted.
+#
+# To enable this hook, rename this file to "prepare-commit-msg".
+#
+# Automatically adds Topic-Placeholders, User, JIRA-Ticket and branch description (if available) to every commit message.
+#
+
+JIRA_TICKET=$(git rev-parse --abbrev-ref HEAD | grep -Eo '([A-Z]{3,}-)([0-9]+)' -m 1)
+USER=git var GIT_AUTHOR_IDENT
+NAME=$(git branch | grep '*' | sed 's/* //') 
+DESCRIPTION=$(git config branch."$NAME".description)
+
+echo "[<TOPIC> : $USER] <DETAILS> - $JIRA_TICKET"|cat - "$1" > /tmp/out && mv /tmp/out "$1"
+if [ -n "$DESCRIPTION" ] 
+then
+   echo "" >> "$1"
+   echo $DESCRIPTION >> "$1"
+fi

--- a/githooks/prepare-commit-message.sample
+++ b/githooks/prepare-commit-message.sample
@@ -6,10 +6,15 @@
 # message's source.  The hook's purpose is to edit the commit
 # message file.  If the hook fails with a non-zero status,
 # the commit is aborted.
+# 
+# To configure, uncomment $HOOK_MESSAGE and add the desired message in the quotes.
+# If the HOOK_MESSAGE is not set the commit message that gets prepared will be blank (default git commit behavior)
 #
 # To enable this hook, rename this file to "prepare-commit-msg".
 #
-# Automatically adds Topic-Placeholders, User, JIRA-Ticket and branch description (if available) to every commit message.
+# Automatically adds desired text to the start of your commit message.
+# Supports pulling the current git User ($USER), the JIRA-Ticket ($JIRA_TICKET)
+# branch name ($NAME), and branch description ($DESCRIPTION) to every commit message.
 #
 
 JIRA_TICKET=$(git rev-parse --abbrev-ref HEAD | grep -Eo '([A-Z]{3,}-)([0-9]+)' -m 1)
@@ -17,8 +22,8 @@ USER=git var GIT_AUTHOR_IDENT
 NAME=$(git branch | grep '*' | sed 's/* //') 
 DESCRIPTION=$(git config branch."$NAME".description)
 
-# if you want a different message, add it here
-HOOK_MESSAGE="[<TOPIC> : $USER] <DETAILS> - $JIRA_TICKET"
+# Variable to set desired message
+#HOOK_MESSAGE="[<TOPIC> : $USER] <DETAILS> - $JIRA_TICKET"
 
 echo "$HOOK_MESSAGE"|cat - "$1" > /tmp/out && mv /tmp/out "$1"
 if [ -n "$DESCRIPTION" ] 


### PR DESCRIPTION
Initial push where the commit message is not gracefully handling the use of passing a message `-m`. Currently it adds the message to the end after the "$JIRA_TICKET"

You can also reconfigure the order of line 20 to do what you want and put it before it prints. Sample output:
status of repo:
```
On branch topic/EVM-1304-enhance-parametrize-pqe-scripts
Your branch is up-to-date with 'origin/topic/EVM-1304-enhance-parametrize-pqe-scripts'.
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

	new file:   ui.resources/.npmrc
```
vim view of `git commit`
```vim
[<TOPIC> : efrain] <DETAILS> - EVM-1304

# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
# On branch topic/EVM-1304-enhance-parametrize-pqe-scripts
# Your branch is up-to-date with 'origin/topic/EVM-1304-enhance-parametrize-pqe-scripts'.
#
# Changes to be committed:
#   new file:   ui.resources/.npmrc
```